### PR TITLE
Add Policy Logic

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * API of the Logic component
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of policies */
+    ObservableList<Policy> getFilteredPolicyList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 import seedu.address.storage.Storage;
 
 /**
@@ -69,6 +70,10 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    public ObservableList<Policy> getFilteredPolicyList() {
+        return model.getFilteredPolicyList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * Container for user visible messages.
@@ -15,7 +16,9 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_POLICY_ID = "The policy id provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_POLICY_LISTED_OVERVIEW = "%1$d policies listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
@@ -47,5 +50,20 @@ public class Messages {
         person.getTags().forEach(builder::append);
         return builder.toString();
     }
+
+    /**
+     * Formats the {@code person} for display to the user.
+     */
+    public static String format(Policy policy) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(policy.getName())
+                .append("; id: ")
+                .append(policy.getId())
+                .append("; Description: ")
+                .append(policy.getDescription());
+        return builder.toString();
+    }
+
+
 
 }

--- a/src/main/java/seedu/address/logic/commands/RemovePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemovePolicyCommand.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.policy.Policy;
+
+/**
+ * Removes a policy identified using policy id from the address book.
+ */
+public class RemovePolicyCommand extends Command {
+
+    public static final String COMMAND_WORD = "remove policy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the policy identified by the id used in the policy list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_REMOVE_POLICY_SUCCESS = "Removed Policy: %1$s";
+
+    private final Index targetIndex;
+
+    public RemovePolicyCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Policy> lastShownList = model.getFilteredPolicyList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_ID);
+        }
+
+        Policy policyToRemove = lastShownList.get(targetIndex.getZeroBased());
+        model.removePolicy(policyToRemove);
+        return new CommandResult(String.format(MESSAGE_REMOVE_POLICY_SUCCESS, Messages.format(policyToRemove)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemovePolicyCommand)) {
+            return false;
+        }
+
+        RemovePolicyCommand otherRemovePolicyCommand = (RemovePolicyCommand) other;
+        return targetIndex.equals(otherRemovePolicyCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPolicyCommand.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POLICIES;
+
+import seedu.address.model.Model;
+
+/**
+ * Returns a view list of policies in the address book to the user.
+ */
+public class ViewPolicyCommand extends Command {
+
+    public static final String COMMAND_WORD = "view p";
+
+    public static final String MESSAGE_SUCCESS = "Viewing all policies";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,8 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.UniquePolicyList;
 
 /**
  * Wraps all data at the address-book level
@@ -16,6 +18,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+    private final UniquePolicyList policies;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,6 +29,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+    }
+    {
+        policies = new UniquePolicyList();
     }
 
     public AddressBook() {}
@@ -55,6 +61,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setPolicies(newData.getPolicyList());
     }
 
     //// person-level operations
@@ -106,6 +113,85 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Person> getPersonList() {
         return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddressBook)) {
+            return false;
+        }
+
+        AddressBook otherAddressBook = (AddressBook) other;
+        return persons.equals(otherAddressBook.persons);
+    }
+
+    @Override
+    public int hashCode() {
+        return persons.hashCode();
+    }
+
+    /**
+     * Replaces the contents of the policy list with {@code policies}.
+     * {@code policies} must not contain duplicate policies.
+     */
+    public void setPolicies(List<Policy> policies) {
+        this.policies.setPolicies(policies);
+    }
+
+    //// policy-level operations
+
+    /**
+     * Returns true if a policy with the same id as {@code policy} exists in the address book.
+     */
+    public boolean hasPolicy(Policy policy) {
+        requireNonNull(policy);
+        return policies.contains(policy);
+    }
+
+    /**
+     * Adds a policy to the address book.
+     * The policy must not already exist in the address book.
+     */
+    public void addPolicy(Policy p) {
+        policies.add(p);
+    }
+
+    /**
+     * Replaces the given policy {@code target} in the list with {@code editedPolicy}.
+     * {@code target} must exist in the address book.
+     * The policy id of {@code editedPolicy} must not be the same as another existing policy in the address book.
+     */
+    public void setPolicy(Policy target, Policy editedPolicy) {
+        requireNonNull(editedPolicy);
+
+        policies.setPolicy(target, editedPolicy);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removePolicy(Policy key) {
+        policies.remove(key);
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("persons", persons)
+                .toString();
+    }
+
+    @Override
+    public ObservableList<Policy> getPolicyList() {
+        return policies.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * The API of the Model component.
@@ -13,6 +14,7 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Policy> PREDICATE_SHOW_ALL_POLICIES = unused -> false;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -84,4 +86,37 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns true if a policy with the same id as {@code policy} exists in the address book.
+     */
+    boolean hasPolicy(Policy id);
+
+    /**
+     * Deletes the given policy.
+     * The policy must exist in the address book.
+     */
+    void deletePolicy(Policy target);
+
+    /**
+     * Adds the given policy.
+     * {@code policy} must not already exist in the address book.
+     */
+    void addPolicy(Policy policy);
+
+    /**
+     * Replaces the given policy {@code target} with {@code editedPolicy}.
+     * {@code target} must exist in the address book.
+     * The policy id of {@code editedPolicy} must not be the same as another existing policy in the address book.
+     */
+    void setPolicy(Policy target, Policy editedPolicy);
+
+    /** Returns an unmodifiable view of the filtered policy list */
+    ObservableList<Policy> getFilteredPolicyList();
+
+    /**
+     * Updates the filter of the filtered policy list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredPolicyList(Predicate<Policy> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Policy> filteredPolicies;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredPolicies = new FilteredList<>(this.addressBook.getPolicyList());
     }
 
     public ModelManager() {
@@ -94,8 +97,19 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPolicy(Policy policy) {
+        requireNonNull(policy);
+        return addressBook.hasPolicy(policy);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+    }
+
+    @Override
+    public void removePolicy(Policy target) {
+        addressBook.removePolicy(target);
     }
 
     @Override
@@ -105,10 +119,23 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addPolicy(Policy policy) {
+        addressBook.addPolicy(policy);
+        updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
+    }
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void setPolicy(Policy target, Policy editedPolicy) {
+        requireAllNonNull(target, editedPolicy);
+
+        addressBook.setPolicy(target, editedPolicy);
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -122,10 +149,26 @@ public class ModelManager implements Model {
         return filteredPersons;
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Policy} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Policy> getFilteredPolicyList() {
+        return filteredPolicies;
+    }
+
+
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredPolicyList(Predicate<Policy> predicate) {
+        requireNonNull(predicate);
+        filteredPolicies.setPredicate(predicate);
     }
 
     @Override
@@ -142,7 +185,10 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && filteredPolicies.equals(otherModelManager.filteredPolicies);
     }
+
+
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * Unmodifiable view of an address book
@@ -14,4 +15,9 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
+    /**
+     * Returns an unmodifiable view of the policies list.
+     * This list will not contain any duplicate policies.
+     */
+    ObservableList<Policy> getPolicyList();
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPolicy.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPolicy.java
@@ -1,0 +1,79 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.policy.Id;
+import seedu.address.model.policy.Description;
+import seedu.address.model.policy.Name;
+import seedu.address.model.policy.Policy;
+
+
+
+/**
+ * Jackson-friendly version of {@link Policy}.
+ */
+class JsonAdaptedPolicy {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Policy's %s field is missing!";
+
+    private final String id;
+    private final String name;
+    private final String description;
+
+    /**
+     * Constructs a {@code JsonAdaptedPolicy} with the given policy details.
+     */
+    @JsonCreator
+    public JsonAdaptedPolicy(@JsonProperty("id") String id, @JsonProperty("name") String name,
+                             @JsonProperty("description") String description) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+    }
+
+    /**
+     * Converts a given {@code Policy} into this class for Jackson use.
+     */
+    public JsonAdaptedPolicy(Policy source) {
+        id = source.getId().fullId;
+        name = source.getName().fullName;
+        description = source.getDescription().fullDescription;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted policy object into the model's {@code Policy} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted policy.
+     */
+    public Policy toModelType() throws IllegalValueException {
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (id == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName()));
+        }
+        if (!Id.isValidId(id)) {
+            throw new IllegalValueException(Id.MESSAGE_CONSTRAINTS);
+        }
+        final Id modelId = new Id(id);
+
+        if (description == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
+        }
+        if (!Description.isValidDescription(description)) {
+            throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
+        }
+        final Description modelDescription = new Description(description);
+
+        return new Policy(modelId, modelName, modelDescription);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -20,15 +21,19 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_POLICY = "Policies list contains duplicate policy(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedPolicy> policies = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("policies") List<JsonAdaptedPolicy> policies) {
         this.persons.addAll(persons);
+        this.policies.addAll(policies);
     }
 
     /**
@@ -38,6 +43,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        policies.addAll(source.getPolicyList().stream().map(JsonAdaptedPolicy::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +59,13 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addPerson(person);
+        }
+        for (JsonAdaptedPolicy jsonAdaptedPolicy : policies) {
+            Policy policy = jsonAdaptedPolicy.toModelType();
+            if (addressBook.hasPolicy(policy)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_POLICY);
+            }
+            addressBook.addPolicy(policy);
         }
         return addressBook;
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -35,6 +35,8 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    private PolicyListPanel policyListPanel;
+
     @FXML
     private StackPane commandBoxPlaceholder;
 

--- a/src/main/java/seedu/address/ui/PolicyCard.java
+++ b/src/main/java/seedu/address/ui/PolicyCard.java
@@ -1,0 +1,46 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.policy.Policy;
+
+/**
+ * A UI component that displays information of a {@code Policy}.
+ */
+public class PolicyCard extends UiPart<Region> {
+
+    private static final String FXML = "PolicyListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Policy policy;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+    @FXML
+    private Label description;
+
+    /**
+     * Creates a {@code PolicyCode} with the given {@code Policy} and index to display.
+     */
+    public PolicyCard(Policy policy, int displayedIndex) {
+        super(FXML);
+        this.policy = policy;
+        name.setText(policy.getName().fullName);
+        id.setText(policy.getId().fullId);
+        description.setText(policy.getDescription().fullDescription);
+    }
+}
+

--- a/src/main/java/seedu/address/ui/PolicyListPanel.java
+++ b/src/main/java/seedu/address/ui/PolicyListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.policy.Policy;
+
+/**
+ * Panel containing the list of policies.
+ */
+public class PolicyListPanel extends UiPart<Region> {
+    private static final String FXML = "PolicyListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(PolicyListPanel.class);
+
+    @FXML
+    private ListView<Policy> policyListView;
+
+    /**
+     * Creates a {@code PolicyListPanel} with the given {@code ObservableList}.
+     */
+    public PolicyListPanel(ObservableList<Policy> policyList) {
+        super(FXML);
+        policyListView.setItems(policyList);
+        policyListView.setCellFactory(listView -> new PolicyListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Policy} using a {@code PolicyCard}.
+     */
+    class PolicyListViewCell extends ListCell<Policy> {
+        @Override
+        protected void updateItem(Policy policy, boolean empty) {
+            super.updateItem(policy, empty);
+
+            if (empty || policy == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new PolicyCard(policy, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Add policy commands, utils, logic and ui

There is a need to have view and remove commands for policy for a MVP. The Ui and logic that supports viewing and removing policies improve user experience.

Let's add the RemovePolicy and ViewPolicy Commands, as well as update the storage for the addressbook and add a storage for policy. Let's also add policy related method into the util, as well as create a PolicyCard and PolicyListPanel in Ui to display policies. Let's provide an early iteration of our implementation for our teamates to refer to and work on their portion of code, given they may cross reference to policy to implement more MVP features.

Closes #48