### PR TITLE
Update ViewPolicy for Contracts

### DIFF
--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -2,12 +2,13 @@ package seedu.address.model.policy;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.contract.Contract;
 
@@ -20,7 +21,7 @@ public class Policy {
     private final PolicyName policyName;
     private final PolicyDetails policyDetails;
     private final PolicyId policyId;
-    private final Set<Contract> contracts = new HashSet<>();
+    private final ObservableSet<Contract> contracts = FXCollections.observableSet(new HashSet<>());
 
     /**
      * Fields must be present and not null.
@@ -56,8 +57,8 @@ public class Policy {
         return policyId;
     }
 
-    public Set<Contract> getContracts() {
-        return Collections.unmodifiableSet(contracts);
+    public ObservableSet<Contract> getContracts() {
+        return FXCollections.unmodifiableObservableSet(contracts);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PolicyCard.java
+++ b/src/main/java/seedu/address/ui/PolicyCard.java
@@ -1,13 +1,16 @@
 package seedu.address.ui;
 
+import javafx.collections.SetChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.contract.Contract;
 import seedu.address.model.policy.Policy;
 
 /**
- * An UI component that displays information of a {@code Policy}.
+ * A UI component that displays information of a {@code Policy}.
  */
 public class PolicyCard extends UiPart<Region> {
 
@@ -33,6 +36,8 @@ public class PolicyCard extends UiPart<Region> {
     private Label pid;
     @FXML
     private Label details;
+    @FXML
+    private FlowPane contracts;
 
     /**
      * Creates a {@code PolicyCode} with the given {@code Policy} and index to display.
@@ -44,5 +49,18 @@ public class PolicyCard extends UiPart<Region> {
         name.setText(policy.getName().value);
         pid.setText(policy.getId().value);
         details.setText(policy.getDetails().value);
+
+        //Initial populate
+        updateContractChips();
+
+        //Add listener for new incoming contracts
+        policy.getContracts().addListener((SetChangeListener<Contract>) change -> {
+            updateContractChips();
+        });
+    }
+
+    private void updateContractChips() {
+        contracts.getChildren().clear();
+        policy.getContracts().forEach(c -> contracts.getChildren().add(new Label(c.getCId().value)));
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -350,3 +350,17 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#contracts {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#contracts .label {
+    -fx-text-fill: white;
+    -fx-background-color: #FFA500;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}

--- a/src/main/resources/view/PolicyListCard.fxml
+++ b/src/main/resources/view/PolicyListCard.fxml
@@ -3,6 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
@@ -26,6 +27,7 @@
                 </Label>
                 <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
             </HBox>
+            <FlowPane fx:id="contracts" />
             <Label fx:id="pid" styleClass="cell_small_label" text="\$pid" />
             <Label fx:id="details" styleClass="cell_small_label" text="\$details" />
         </VBox>


### PR DESCRIPTION
Update Ui to show Contract chips for ViewPolicy

This allow users to see which contracts are currently tagged under the policy when viewing policies

Let's update the Ui to include contract chips, and change contract set under policy to an observableset for dynamic ui updates.

Closes #146