### PR TITLE
Add check that Premium cannot be 0.

### DIFF
--- a/src/main/java/seedu/address/model/contract/ContractPremium.java
+++ b/src/main/java/seedu/address/model/contract/ContractPremium.java
@@ -13,7 +13,7 @@ import java.math.RoundingMode;
 public class ContractPremium {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Contract premium should be a non-negative number.";
+            "Contract premium should be more than 0.";
 
     //Used to round off to 2 decimal places
     private static final int SCALE = 2;
@@ -43,7 +43,7 @@ public class ContractPremium {
         }
         try {
             BigDecimal normalized = test.setScale(SCALE, RoundingMode.HALF_UP);
-            return normalized.compareTo(BigDecimal.ZERO) >= 0;
+            return normalized.compareTo(BigDecimal.ZERO) > 0;
         } catch (ArithmeticException e) {
             return false;
         }
@@ -59,7 +59,7 @@ public class ContractPremium {
         try {
             BigDecimal value = new BigDecimal(test);
             BigDecimal normalized = value.setScale(SCALE, RoundingMode.HALF_UP);
-            return normalized.compareTo(BigDecimal.ZERO) >= 0;
+            return normalized.compareTo(BigDecimal.ZERO) > 0;
         } catch (NumberFormatException | ArithmeticException e) {
             return false;
         }

--- a/src/test/java/seedu/address/model/contract/ContractPremiumTest.java
+++ b/src/test/java/seedu/address/model/contract/ContractPremiumTest.java
@@ -17,9 +17,9 @@ public class ContractPremiumTest {
         assertFalse(ContractPremium.isValidContractPremium(" ")); // spaces only
         assertFalse(ContractPremium.isValidContractPremium("-50")); // negative value
         assertFalse(ContractPremium.isValidContractPremium("abc")); // non-numeric
+        assertFalse(ContractPremium.isValidContractPremium("0")); // zero value
 
         // valid premiums
-        assertTrue(ContractPremium.isValidContractPremium("0")); // zero value
         assertTrue(ContractPremium.isValidContractPremium("100")); // integer value
         assertTrue(ContractPremium.isValidContractPremium("99.99")); // valid decimal value
         assertTrue(ContractPremium.isValidContractPremium("0.01")); // minimum positive value


### PR DESCRIPTION
Add a check with message "Contract Premium cannot be 0". 
As ContractPremium rounds up the cost, the technical smallest passable value is 0.005, as it rounds up to 0.01.

Resolves #198 