### PR TITLE
Tighten duplicate contract logic

### DIFF
--- a/src/main/java/seedu/address/model/contract/Contract.java
+++ b/src/main/java/seedu/address/model/contract/Contract.java
@@ -103,10 +103,7 @@ public class Contract {
 
         return otherContract != null
                 && otherContract.getNric().equals(getNric())
-                && otherContract.getPId().equals(getPId())
-                && otherContract.getDate().equals(getDate())
-                && otherContract.getExpiryDate().equals(getExpiryDate())
-                && otherContract.getPremium().equals(getPremium());
+                && otherContract.getPId().equals(getPId());
     }
 
     public static int compareByExpiryDate(Contract c1, Contract c2) {


### PR DESCRIPTION
Previously contracts were not different as long as any field is different. That is name and ContractId does not affect duplicate contract checks. But as long as any of the below fields are different, even if the rest are identical, the contract is different:
* Nric
* PolicyId
* Date Signed
* Expiry Date
* Premium

Now contracts are duplicate as long Nric and PolicyId is the same

Resolves #308
Resolves #340 
Resolves #342