### PR TITLE
Handle UTF-8 with BOM encoding

### DIFF
--- a/src/main/java/seedu/address/logic/parser/PolicyFileParser.java
+++ b/src/main/java/seedu/address/logic/parser/PolicyFileParser.java
@@ -40,6 +40,10 @@ public class PolicyFileParser {
             int lineNumber = 0;
 
             while ((line = reader.readLine()) != null) {
+                // Handle UTF-8 with BOM encoding
+                if (lineNumber == 0) {
+                    line = line.replace("\ufeff", "");
+                }
                 lineNumber++;
                 policies.add(parseLine(lineNumber, line));
             }


### PR DESCRIPTION
Resolves #353 
Specification for policy file to be a plain text file with UTF-8 encoding has been resolved in #371 